### PR TITLE
✨ADD : 특별호 같은 숫자가 아닐 때 호 중복 표시 제거 및 카테고리 API 연결

### DIFF
--- a/src/components/Category/Categories.tsx
+++ b/src/components/Category/Categories.tsx
@@ -4,7 +4,7 @@ import { CATEGORIES } from '@/contents/category';
 import { useRouter } from 'next/router';
 import Slider from 'react-slick';
 
-const Categories = () => {
+const Categories = ({ categories }: any) => {
   const router = useRouter();
 
   const settings = {
@@ -14,8 +14,8 @@ const Categories = () => {
     slidesToScroll: 6,
   };
 
-  const onClickCategory = (category: any) => {
-    if (category === '전체') {
+  const onClickCategory = (category: number) => {
+    if (category === 0) {
       return router.replace({
         pathname: '/newsletter',
       });
@@ -23,7 +23,8 @@ const Categories = () => {
     router.replace({
       pathname: '/newsletter',
       query: {
-        keyword: category,
+        keyword: '',
+        category: category,
         page: 1,
       },
     });
@@ -32,7 +33,8 @@ const Categories = () => {
   return (
     <Wrapper>
       <StyledSlider {...settings}>
-        {CATEGORIES.map((category) => (
+        <CategoryTag category={{ id: 0, name: '전체' }} onClick={onClickCategory} />
+        {categories.map((category: any) => (
           <CategoryTag key={category.id} category={category} onClick={onClickCategory} />
         ))}
       </StyledSlider>

--- a/src/components/Category/CategoryTag.tsx
+++ b/src/components/Category/CategoryTag.tsx
@@ -11,8 +11,15 @@ const CategoryTag = ({
   onClick: (category: any) => void;
 }) => {
   return (
-    <Wrapper background={category.color} onClick={() => onClick(category.value)}>
-      <Typography15 text={category.label} color={theme.colors.gray9} weight={400} />
+    <Wrapper
+      background={
+        [theme.colors.blue1, theme.colors.green1, theme.colors.yellow1, theme.colors.red1][
+          Math.floor(Math.random() * 4)
+        ]
+      }
+      onClick={() => onClick(category.id)}
+    >
+      <Typography15 text={category.name} color={theme.colors.gray9} weight={400} />
     </Wrapper>
   );
 };

--- a/src/components/ui/cards/ContentCard.tsx
+++ b/src/components/ui/cards/ContentCard.tsx
@@ -29,7 +29,11 @@ const ContentCard = ({
     >
       <TitleWrapper>
         {subtitle && (
-          <Typography13 text={`${subtitle}호`} color={color ?? theme.colors.gray9} weight={400} />
+          <Typography13
+            text={`${subtitle.includes('호') ? subtitle : subtitle + '호'}`}
+            color={color ?? theme.colors.gray9}
+            weight={400}
+          />
         )}
         <Typography15 text={title} color={color ?? theme.colors.gray9} weight={700} />
         {date && <Typography11 text={date} color={color ?? theme.colors.gray9} weight={400} />}

--- a/src/models/category.ts
+++ b/src/models/category.ts
@@ -1,5 +1,5 @@
 export type Category = {
-    label: string;
-    value: string;
-    color: string;
-}
+  id: number;
+  name: string;
+  // color: string;
+};

--- a/src/pages/newsletter/index.tsx
+++ b/src/pages/newsletter/index.tsx
@@ -6,14 +6,13 @@ import { useNewslettersStore } from '@/stores/newsletters';
 
 import SearchNewsletter from '@/components/Newsletter/SearchNewsletter';
 import Categories from '@/components/Category/Categories';
-import NewsletterHeader from '@/components/Newsletter/NewsletterHeader';
 import NewsletterPagination from '@/components/Newsletter/NewsletterPagination';
 import ContentCard from '@/components/ui/cards/ContentCard';
 import Typography24 from '@/components/ui/textStyles/Typography24';
 import theme from '@/styles/theme';
 import TitleBox from '@/components/ui/titleBoxes/TitleBox';
 
-const Newsletter = ({ articles, page, totalPages, keyword }: any) => {
+const Newsletter = ({ articles, page, totalPages, keyword, categories }: any) => {
   useEffect(() => {
     useNewslettersStore.getState().setNewsletters(articles, page, totalPages, keyword);
   }, [articles]);
@@ -27,7 +26,7 @@ const Newsletter = ({ articles, page, totalPages, keyword }: any) => {
         />
         <SearchSection>
           <SearchNewsletter />
-          <Categories />
+          <Categories categories={categories} />
         </SearchSection>
       </InfoSection>
 
@@ -125,12 +124,16 @@ export async function getServerSideProps(context: any) {
     .getState()
     .setNewsletters(results.results, page, Number(results.total_pages) - 1, keyword);
 
+  const getCategories = await fetch('https://api.gongsamo.kr/categories');
+  const categories = await getCategories.json();
+
   return {
     props: {
       articles: useNewslettersStore.getState().newsletters,
       totalPages: useNewslettersStore.getState().totalPages,
       page: useNewslettersStore.getState().page,
       keyword,
+      categories,
     },
   };
 }

--- a/src/stores/newsletter.ts
+++ b/src/stores/newsletter.ts
@@ -4,6 +4,7 @@ import { devtools } from 'zustand/middleware';
 type NewsletterState = {
   newsletter: string;
   setNewsletter: (newsletter: string) => void;
+  setCategories: (categories: any) => void;
 };
 
 export const useNewsletterStore = create<NewsletterState>()(
@@ -12,6 +13,9 @@ export const useNewsletterStore = create<NewsletterState>()(
       newsletter: '',
       setNewsletter: (newsletter) => {
         set((state) => ({ ...state, newsletter }));
+      },
+      setCategories: (categories) => {
+        set((state) => ({ ...state, categories }));
       },
     }),
     {

--- a/src/stores/newsletters.ts
+++ b/src/stores/newsletters.ts
@@ -27,7 +27,7 @@ export const useNewslettersStore = create<NewslettersState>()(
       //   set((state) => ({ ...state, newsletters, page, keyword })),
 
       setNewsletters: (newsletters, page, totalPages, keyword) =>
-        set((state) => ({ ...state, newsletters, page, totalPages, keyword })),
+        set(() => ({ newsletters, page, totalPages, keyword })),
       setPageableNewsletters: (query, pageableNewsletters) =>
         set((state) => ({
           ...state,


### PR DESCRIPTION
## 작업 내용
- 특별호-> 특별호호 같은 형태로 숫자가 아닐 때 '호'가 중복 표시되는 문제 해결
- 카테고리 API 연결
- 카테고리 클릭시 뉴스레터 데이터 요청 로직 변경

## 스크린샷
<img width="673" alt="스크린샷 2023-07-30 오후 6 21 04" src="https://github.com/Gongsamo-Korea/gongsamo-web/assets/103479322/4cce46fb-cef6-40b2-8da6-9e7751bd07ec">

## 기타
- 카테고리 버튼 클릭시 뉴스레터 데이터 요청시 데이터 변화가 없음..왜그런지 모르겠습니다..하핫
- 우선 카테고리 불러오는 API 자체는 반영해놨습니다